### PR TITLE
Remove pudb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,6 @@ matplotlib
 scikit-image
 scikit-learn
 sphinx
-pudb
 pytest
 pytest-pep8
 pytest-cov
-pytest-pudb


### PR DESCRIPTION
Remove pudb and pytest-pudb from requirements to see if that lets the
travis.ci platform build.