### PR TITLE
Fix .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ cache:
 install:
         - pip install -r requirements.txt
 script:
-        -pytest -v --pep8 --cov
+        - pytest -v --pep8 --cov


### PR DESCRIPTION
Missing a ' ' so file was calling -pytest -v --pep8 --cov instead of
pytest -v --pep8 --cov and travis.ci build was continuously failing.
Hopeufully this fixes it.